### PR TITLE
Script fails to find protobuf version

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -1,0 +1,193 @@
+#!/bin/bash -x
+#
+# Follow https://github.com/cjweeks/tensorflow-cmake
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <build-dir> <install-dir>"
+    exit 0
+fi
+
+BUILDDIR=$(readlink -f "$1")
+INSTALLDIR=$(readlink -f "$2")
+
+#####################################################################
+# optionals that can be overriden from outside
+
+BAZEL_VER=${$BAZEL_VER:-"0.4.5"}
+CACHEDIR=${CACHEDIR:-"$INSTALLDIR/cache"}
+OSTYPE=${OSTYPE:-"linux-x86_64"}
+PYTHONBIN=${PYTHONBIN:-"/usr/bin/python"}
+PYTHONLIB=${PYTHONLIB:-"/usr/lib/python2.7/dist-packages"}
+COMPILE_ARCH=${COMPILE_ARCH:-native}
+USE_MKL=${USE_MKL:-N}
+USE_JEMALLOC=${USE_JEMALLOC:-Y}
+USE_CLOUD=${USE_CLOUD:-N}
+USE_HADOOP=${USE_HADOOP:-N}
+USE_XLA=${USE_XLA:-N}
+USE_VERBS=${USE_VERBS:-N}
+USE_OPENCL=${USE_OPENCL:-N}
+USE_CUDA=${USE_CUDA:-N}
+
+
+#####################################################################
+# FUNCTIONS/HELPERS
+
+function install_packages()
+{
+    for pkg in $*; do
+        if ! dpkg -l $pkg > /dev/null 2>&1 ; then
+            sudo apt-get -y install $pkg || exit 1
+        fi
+    done
+}
+
+function install_bazel()
+{
+    BAZEL_DEB=bazel_${BAZEL_VER}-${OSTYPE}.deb
+    if ! dpkg -l bazel > /dev/null 2>&1; then
+        #wget https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VER/bazel-$BAZEL_VER-installer-$OSTYPE.sh
+        if [ ! -e $BAZEL_DEB ]; then
+            wget --no-check-certificate https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VER/$BAZEL_DEB -O $CACHEDIR/$BAZEL_DEB || exit 1
+        fi
+        sudo dpkg -i $CACHEDIR/$BAZEL_DEB || exit 1
+    fi
+}
+
+####################################################################
+# pre-requisites
+install_packages git autoconf build-essential automake libtool curl \
+                 make g++ unzip python-numpy swig \
+                 python-dev python-wheel openjdk-8-jdk \
+                 pkg-config zip zlib1g-dev wget
+install_bazel
+
+
+####################################################################
+# Download and compile tensorflow from github
+# Directory will be:
+# $BUILDDIR
+#     - tensorflow-cmake
+#     - tensorflow-github
+#
+#rm -rf $INSTALLDIR
+mkdir -p $INSTALLDIR/{include,lib,bin,share,cache}
+mkdir -p $INSTALLDIR/share/cmake/Modules
+rm -rf $BUILDDIR
+mkdir -p $BUILDDIR
+
+
+cd $BUILDDIR
+if [ ! -e $CACHEDIR/tensorflow-cmake.tgz ]; then
+    git clone https://github.com/Vitorian/tensorflow-cmake.git tensorflow-cmake
+    tar czf $CACHEDIR/tensorflow-cmake.tgz tensorflow-cmake
+fi
+rm -rf tensorflow-cmake
+tar xzf $CACHEDIR/tensorflow-cmake.tgz
+
+if [ ! -e $CACHEDIR/tensorflow-github.tgz ]; then
+    git clone https://github.com/tensorflow/tensorflow  tensorflow-github
+    tar czf $CACHEDIR/tensorflow-github.tgz tensorflow-github
+fi
+rm -rf tensorflow-github
+tar xzf $CACHEDIR/tensorflow-github.tgz
+
+####################################################################
+# This specifies a new build rule, producing libtensorflow_all.so,
+# that includes all the required dependencies for integration with
+# a C++ project.
+# Build the shared library and copy it to $INSTALLDIR
+cd $BUILDDIR/tensorflow-github
+cat <<EOF >> tensorflow/BUILD
+# Added build rule
+cc_binary(
+    name = "libtensorflow_all.so",
+    linkshared = 1,
+    linkopts = ["-Wl,--version-script=tensorflow/tf_version_script.lds"], # if use Mac remove this line
+    deps = [
+        "//tensorflow/cc:cc_ops",
+        "//tensorflow/core:framework_internal",
+        "//tensorflow/core:tensorflow",
+    ],
+)
+EOF
+
+# except script to respond to ./configure
+#> configure_script.exp
+cat <<EOF | expect
+spawn ./configure
+sleep 1
+
+expect "Please specify the location of python"
+send "$PYTHONBIN\n"
+
+expect "Please input the desired Python library path to use.  Default is"
+send "$PYTHONLIB\n"
+
+expect "Do you wish to build TensorFlow with MKL support? \\\\\[y/N\\\\\]"
+send "$USE_MKL\n"
+
+expect -re "Please specify optimization flags .*: "
+send -- "-march=$COMPILE_ARCH -mtune=$COMPILE_ARCH\n"
+
+expect "Do you wish to use jemalloc"
+send "$USE_JEMALLOC\n"
+
+expect "Do you wish to build TensorFlow with Google Cloud Platform support? \\\\\[y/N\\\\\]"
+send "$USE_CLOUD\n"
+
+expect "Do you wish to build TensorFlow with Hadoop File System support? \\\\\[y/N\\\\\]"
+send "$USE_HADOOP\n"
+
+expect "Do you wish to build TensorFlow with the XLA just-in-time compiler (experimental)? \\\\\[y/N\\\\\]"
+send "$USE_XLA\n"
+
+expect "Do you wish to build TensorFlow with VERBS support? \\\\\[y/N\\\\\]"
+send "$USE_VERBS\n"
+
+expect "Do you wish to build TensorFlow with OpenCL support? \\\\\[y/N\\\\\]"
+send "$USE_OPENCL\n"
+
+expect "Do you wish to build TensorFlow with CUDA support? \\\\\[y/N\\\\\]"
+send "$USE_CUDA\n"
+
+expect eof
+EOF
+
+#expect configure_script.exp
+#./configure < configure_answers.txt
+bazel build tensorflow:libtensorflow_all.so
+
+# copy the library to the install directory
+cp bazel-bin/tensorflow/libtensorflow_all.so $INSTALLDIR/lib
+
+# Copy the source to $INSTALLDIR/include/google and remove unneeded items:
+mkdir -p $INSTALLDIR/include/google/tensorflow
+cp -r tensorflow $INSTALLDIR/include/google/tensorflow/
+find $INSTALLDIR/include/google/tensorflow/tensorflow -type f  ! -name "*.h" -delete
+
+# Copy all generated files from bazel-genfiles:
+cp  bazel-genfiles/tensorflow/core/framework/*.h  $INSTALLDIR/include/google/tensorflow/tensorflow/core/framework
+cp  bazel-genfiles/tensorflow/core/kernels/*.h  $INSTALLDIR/include/google/tensorflow/tensorflow/core/kernels
+cp  bazel-genfiles/tensorflow/core/lib/core/*.h  $INSTALLDIR/include/google/tensorflow/tensorflow/core/lib/core
+cp  bazel-genfiles/tensorflow/core/protobuf/*.h  $INSTALLDIR/include/google/tensorflow/tensorflow/core/protobuf
+cp  bazel-genfiles/tensorflow/core/util/*.h  $INSTALLDIR/include/google/tensorflow/tensorflow/core/util
+cp  bazel-genfiles/tensorflow/cc/ops/*.h  $INSTALLDIR/include/google/tensorflow/tensorflow/cc/ops
+
+# Copy the third party directory:
+cp -r third_party $INSTALLDIR/include/google/tensorflow/
+rm -r $INSTALLDIR/include/google/tensorflow/third_party/py
+
+# Note: newer versions of TensorFlow do not have the following directory
+rm -r $INSTALLDIR/include/google/tensorflow/third_party/avro
+
+# Install eigen
+# eigen.sh install <tensorflow-root> [<install-dir> <download-dir>]
+$BUILDDIR/tensorflow-cmake/eigen.sh install "$BUILDDIR/tensorflow-github" "$INSTALLDIR" "$INSTALLDIR/cache"
+# eigen.sh generate installed <tensorflow-root> [<cmake-dir> <install-dir>]
+$BUILDDIR/tensorflow-cmake/eigen.sh generate external "$BUILDDIR/tensorflow-github" "$INSTALLDIR/share/cmake" "$INSTALLDIR"
+
+# Install protobuf
+# protobuf.sh install <tensorflow-root> [<cmake-dir>]
+$BUILDDIR/tensorflow-cmake/protobuf.sh install "$BUILDDIR/tensorflow-github" "$INSTALLDIR" "$INSTALLDIR/cache"
+# protobuf.sh generate installed <tensorflow-root> [<cmake-dir> <install-dir>]
+$BUILDDIR/tensorflow-cmake/protobuf.sh generate installed "$BUILDDIR/tensorflow-github" "$INSTALLDIR/share/cmake" "$INSTALLDIR"

--- a/eigen.sh
+++ b/eigen.sh
@@ -2,6 +2,7 @@
 # Author: Connor Weeks
 
 SCRIPT_DIR="$(cd "$(dirname "${0}")"; pwd)"
+NUMJOBS=${NUMJOBS:-1}
 RED="\033[1;31m"
 YELLOW="\033[1;33m"
 GREEN="\033[0;32m"
@@ -208,7 +209,7 @@ if [ "${MODE}" == "install" ]; then
     mkdir build || fail
     cd build
     cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} .. || fail
-    make || fail
+    make -j$NUMJOBS || fail
     make install || fail
     echo "Installation complete"
     echo "Cleaning up..."

--- a/eigen.sh
+++ b/eigen.sh
@@ -24,7 +24,7 @@ print_usage () {
 |
 |     Generates the cmake files for the given installation of tensorflow
 |     and writes them to <cmake-dir>.  If 'generate installed' is executed,
-|     <install-dir> corresponds to the directory Eigen was installed to; 
+|     <install-dir> corresponds to the directory Eigen was installed to;
 |     defaults to /usr/local.
 |
 | --> ${0} install <tensorflow-source-dir> [<install-dir> <download-dir>]
@@ -55,7 +55,7 @@ find_eigen () {
     FOOTER="\)"
     EIGEN_NAME="${NAME_START}eigen_archive${QUOTE_END}"
     EIGEN_REGEX="${ARCHIVE_HEADER}${ANY}${EIGEN_NAME}${ANY}${FOOTER}"
-    
+
     echo "Finding Eigen version in ${TF_DIR} using method ${1}..."
     # check specified format
     if [ ${1} -eq 0 ]; then
@@ -64,8 +64,8 @@ find_eigen () {
 	EIGEN_HASH_REGEX="eigen_sha256\s*=\s*\\\"${ANY_HEX}\\\"\s*"
 	HASH_SED="s/\s*eigen_sha256${QUOTE_START}\(${ANY_HEX}\)\\\"\s*/\1/p"
 	ARCHIVE_HASH_SED="s/\s*${EIGEN_VERSION_LABEL}${QUOTE_START}\(${ANY_HEX}\)\\\"\s*/\1/p"
-	
-	
+
+
 	EIGEN_TEXT=$(grep -Pzo ${EIGEN_REGEX} ${TF_DIR}/tensorflow/workspace.bzl) || fail
 	EIGEN_ARCHIVE_TEXT=$(grep -Pzo ${EIGEN_ARCHIVE_HASH_REGEX} ${TF_DIR}/tensorflow/workspace.bzl)
 	EIGEN_HASH_TEXT=$(grep -Pzo ${EIGEN_HASH_REGEX} ${TF_DIR}/tensorflow/workspace.bzl)
@@ -84,7 +84,7 @@ find_eigen () {
 	URL_SED="s/\s*url${QUOTE_START}\(${ANY_NO_QUOTES}\)${QUOTE_END}/\1/p"
 	HASH_SED="s/\s*sha256${QUOTE_START}\(${ANY_HEX}\)${QUOTE_END}/\1/p"
 	ARCHIVE_HASH_SED="s=.*/\(${ANY_HEX}\)\\.tar\\.gz=\1=p"
-	
+
 	EIGEN_TEXT=$(grep -Pzo ${EIGEN_REGEX} ${TF_DIR}/tensorflow/workspace.bzl)
 	EIGEN_URL=$(echo "${EIGEN_TEXT}" | sed -n ${URL_SED})
 	EIGEN_URLS[0]=${EIGEN_URL}
@@ -121,7 +121,7 @@ find_eigen () {
 	return 1
     fi
     # return found
-    return 0 
+    return 0
 }
 
 ################################### Script ###################################
@@ -201,14 +201,13 @@ if [ "${MODE}" == "install" ]; then
 	echo "${RED}Could not download eigen${NO_COLOR}"
 	exit 1
     fi
-    
+
     tar -zxvf ${EIGEN_ARCHIVE_HASH}.tar.gz || fail
     cd eigen-eigen-${EIGEN_ARCHIVE_HASH} || fail
     # create build directory and build
     mkdir build || fail
     cd build
-    cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}\
-	  -DINCLUDE_INSTALL_DIR=${INSTALL_DIR}/include/eigen/eigen-eigen-${EIGEN_ARCHIVE_HASH} .. || fail
+    cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} .. || fail
     make || fail
     make install || fail
     echo "Installation complete"
@@ -219,14 +218,14 @@ if [ "${MODE}" == "install" ]; then
     rm -f ${EIGEN_ARCHIVE_HASH}.tar.gz* || fail
 elif [ "${MODE}" == "generate" ]; then
     if [ "${GENERATE_MODE}" == "installed" ]; then
-	# try to locate eigen in INSTALL_DIR		
-	if [ -d "${INSTALL_DIR}/include/eigen/eigen-eigen-${EIGEN_ARCHIVE_HASH}" ]; then		
+	# try to locate eigen in INSTALL_DIR
+	if [ -d "${INSTALL_DIR}/include/eigen/eigen-eigen-${EIGEN_ARCHIVE_HASH}" ]; then
             echo -e "${GREEN}Found Eigen in ${INSTALL_DIR}${NO_COLOR}"
-	else		
- 	    echo -e "${YELLOW}Warning: Could not find Eigen in ${INSTALL_DIR}${NO_COLOR}"			
+	else
+ 	    echo -e "${YELLOW}Warning: Could not find Eigen in ${INSTALL_DIR}${NO_COLOR}"
 	fi
     fi
-    
+
     # output Eigen information to file
     EIGEN_OUT="${CMAKE_DIR}/Eigen_VERSION.cmake"
     echo "set(Eigen_URL ${EIGEN_URL})" > ${EIGEN_OUT} || fail

--- a/protobuf.sh
+++ b/protobuf.sh
@@ -2,6 +2,7 @@
 # Author: Connor Weeks
 
 SCRIPT_DIR="$(cd "$(dirname "${0}")"; pwd)"
+NUMJOBS=${NUMJOBS:-1}
 RED="\033[1;31m"
 YELLOW="\033[1;33m"
 GREEN="\033[0;32m"
@@ -22,7 +23,7 @@ print_usage () {
 |
 |     Generates the cmake files for the given installation of tensorflow
 |     and writes them to <cmake-dir>. If 'generate installed' is executed,
-|     <install-dir> corresponds to the directory Protobuf was installed to; 
+|     <install-dir> corresponds to the directory Protobuf was installed to;
 |     defaults to /usr/local.
 |
 | --> ${0} install <tensorflow-source-dir> [<install-dir> <download-dir>]
@@ -57,16 +58,16 @@ find_protobuf () {
     QUOTE_END="\\\"\s*,\s*"
     FOOTER="\)"
     PROTOBUF_NAME="${NAME_START}com_google_protobuf${QUOTE_END}"
-    
-    
-    
+
+
+
     if [ ${1} -eq 0 ]; then
 	PROTOBUF_REGEX="${HTTP_HEADER}${ANY}${PROTOBUF_NAME}${ANY}${FOOTER}"
 	FOLDER="s/\s*strip_prefix${QUOTE_START}\(${ANY_NO_QUOTES}\)${QUOTE_END}/\1/p"
-	
+
 	URL="s/\s*url${QUOTE_START}\(${ANY_NO_QUOTES}\)${QUOTE_END}/\1/p"
-	
-	
+
+
 	PROTOBUF_TEXT=$(grep -Pzo ${PROTOBUF_REGEX} ${TF_DIR}/tensorflow/workspace.bzl) || fail
 	PROTOBUF_URL=$(echo "${PROTOBUF_TEXT}" | sed -n ${URL})
 	PROTOBUF_URLS[0]=${PROTOBUF_URL}
@@ -191,44 +192,46 @@ if [ "${MODE}" == "install" ]; then
 	    # download protobuf from http archive
 	    cd ${DOWNLOAD_DIR} || fail
 	    wget ${URL} && FOUND_URL=1 && break
-	    
+
 	fi
     done
     if [ ${FOUND_URL} -eq 0 ]; then
 	echo "${RED}Could not download Protobuf${NO_COLOR}"
 	exit 1
     fi
-    
+
     tar -xf ${PROTOBUF_ARCHIVE} || fail
     cd ${PROTOBUF_FOLDER} || fail
-    
-    
-    
-    
+
+
+
+
     # configure
     ./autogen.sh || fail
     ./configure --prefix=${INSTALL_DIR} || fail
     echo "Starting protobuf install."
     # build and install
-    make || fail
+    make -jNUMJOBS || fail
     make check || fail
     make install || fail
-    ldconfig || fail
+    if [ `id -u` == 0 ]; then
+        ldconfig || fail
+    fi
     cd ${DOWNLOAD_DIR} || fail
     rm ${PROTOBUF_ARCHIVE} || fail
     echo "Protobuf has been installed to ${INSTALL_DIR}"
 elif [ "${MODE}" == "generate" ]; then
-    
+
     if [ "${GENERATE_MODE}" == "installed" ]; then
 	# try to locate protobuf in INSTALL_DIR
 	if [ -d "${INSTALL_DIR}/include/google/protobuf" ]; then
             echo -e "${GREEN}Found Protobuf in ${INSTALL_DIR}${NO_COLOR}"
 	else
- 	    echo -e "${YELLOW}Warning: Could not find Protobuf in ${INSTALL_DIR}${NO_COLOR}"	
+ 	    echo -e "${YELLOW}Warning: Could not find Protobuf in ${INSTALL_DIR}${NO_COLOR}"
 	fi
     fi
-    
-    PROTOBUF_OUT="${CMAKE_DIR}/Protobuf_VERSION.cmake"	
+
+    PROTOBUF_OUT="${CMAKE_DIR}/Protobuf_VERSION.cmake"
     echo "set(Protobuf_URL ${PROTOBUF_URL})" > ${PROTOBUF_OUT} || fail
     if [ "${GENERATE_MODE}" == "external" ]; then
 	echo "Wrote Protobuf_VERSION.cmake to ${CMAKE_DIR}"

--- a/protobuf.sh
+++ b/protobuf.sh
@@ -211,7 +211,7 @@ if [ "${MODE}" == "install" ]; then
     ./configure --prefix=${INSTALL_DIR} || fail
     echo "Starting protobuf install."
     # build and install
-    make -jNUMJOBS || fail
+    make -j$NUMJOBS || fail
     make check || fail
     make install || fail
     if [ `id -u` == 0 ]; then

--- a/protobuf.sh
+++ b/protobuf.sh
@@ -56,7 +56,7 @@ find_protobuf () {
     QUOTE_START="\s*=\s*\\\""
     QUOTE_END="\\\"\s*,\s*"
     FOOTER="\)"
-    PROTOBUF_NAME="${NAME_START}protobuf${QUOTE_END}"
+    PROTOBUF_NAME="${NAME_START}com_google_protobuf${QUOTE_END}"
     
     
     


### PR DESCRIPTION
- Protobuf's tag name changed on TensorFlow's github from "protobuf" to "com_google_protobuf". Changing it fixes the issue.
- Added a script to build the recipe on Ubuntu/Debian